### PR TITLE
Fixed small mistake in sample XML and clarified that entry also responds with location

### DIFF
--- a/entries.mkdn
+++ b/entries.mkdn
@@ -54,6 +54,8 @@ Sample POST body:
       <date>2009-10-15</date>
     </entry>
 
+In case the entry was successfully created, you get a HTTP 201 Created back, with the Location header containing the URL of the entry (e.g. https://someaccount.letsfreckle.com/api/entry/123).
+
 ### Entry attributes
 
 * minutes (*required*)

--- a/users.mkdn
+++ b/users.mkdn
@@ -176,7 +176,7 @@ Sample POST body:
 
     <?xml version="1.0" encoding="UTF-8"?>
     <user>
-      <email>foo.bar@example.com</user>
+      <email>foo.bar@example.com</email>
       <first_name>foo</first_name>
       <last_name>bar</last_name>
     </user>
@@ -213,7 +213,7 @@ Sample POST body:
 
     <?xml version="1.0" encoding="UTF-8"?>
     <user>
-      <email>foozinho.barzinho@example.com</user>
+      <email>foozinho.barzinho@example.com</email>
       <first_name>foozinho</first_name>
       <last_name>barzinho</last_name>
     </user>


### PR DESCRIPTION
I noticed that the add and update user example XML contained a small mistake and clarified that create location also responds with a Location header. Just like the other create operations.
