### PR TITLE
Rename `/invoiced_outside_of_noko` => `/marked_as_invoiced`

### DIFF
--- a/content/v2/entries.md
+++ b/content/v2/entries.md
@@ -240,7 +240,7 @@ Update the Entry so that is recognized as being invoiced outside of Noko by prov
 If the entry has already been marked as invoiced outside of Noko, this action modifies the `invoiced_at` date for the entry.
 
 ~~~
-PUT /v2/entries/:id/invoiced_outside_of_noko
+PUT /v2/entries/:id/marked_as_invoiced
 ~~~
 
 ### Input
@@ -266,7 +266,7 @@ Update the Entries provided so that they are recognized as being invoiced outsid
 If an entry has already been marked as invoiced outside of Noko, this action modifies the `invoiced_at` date for that entry.
 
 ~~~
-PUT /v2/entries/invoiced_outside_of_noko
+PUT /v2/entries/marked_as_invoiced
 ~~~
 
 ### Input

--- a/lib/resources/resources.rb
+++ b/lib/resources/resources.rb
@@ -442,7 +442,7 @@ module Noko
       "approved_at" => "2012-01-10T08:33:29Z",
       "approved_by" => SIMPLE_USER,
       "url" => "#{API_V2_URL}/entries/1711626",
-      "invoiced_outside_of_noko_url" => "#{API_V2_URL}/entries/1711626/invoiced_outside_of_noko",
+      "invoiced_outside_of_noko_url" => "#{API_V2_URL}/entries/1711626/marked_as_invoiced",
       "approved_url" => "#{API_V2_URL}/entries/1711626/approved",
       "unapproved_url" => "#{API_V2_URL}/entries/1711626/unapproved",
       "created_at" => "2012-01-09T08:33:29Z",


### PR DESCRIPTION
* Rather than `entries/:id/invoiced_outside_of_noko`, we should use
  `entries/:id/marked_as_invoiced`, since it's a generic endpoint name
  (and we may support other identifiers in the future when marking
  an invoice).
* We'll still use the `invoiced_outside_of_noko_url` Hypermedia URL name
	and the endpoint, for 2 reasons:
  1. It keeps support for folks that use hypermedia URLs, but also do a
     find/replace pass in their code as part of the API migration
  2. It prevents the entry body from being bogged down with 3 references
     to the same action (the freckle version, the noko verison, the
     generic version)